### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: html_unescape
 description: >
   A small library for un-escaping HTML. Supports all Named Character References,
   Decimal Character References and Hexadecimal Character References.
-version: 1.0.1+2
+version: 1.0.1+3
 author: Filip Hracek <filip.hracek@gmail.com>
 homepage: https://github.com/filiph/html_unescape
 

--- a/tool/generate_map.dart
+++ b/tool/generate_map.dart
@@ -14,6 +14,7 @@ main() async {
   var response = await req.close();
   client.close();
   List<String> contents = await response
+      .cast<List<int>>()
       .transform(utf8.decoder)
       .transform(const LineSplitter())
       .toList();


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900