### PR TITLE
Fix pub.dev score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.0-nullsafety.1
+
+- Fix pub.dev score.
+
 ## 2.0.0-nullsafety.0
 
 - Migrate to null safety.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,11 +2,11 @@ name: html_unescape
 description: >
   A small library for un-escaping HTML. Supports all Named Character References,
   Decimal Character References and Hexadecimal Character References.
-version: 2.0.0-nullsafety.0
+version: 2.0.0-nullsafety.1
 homepage: https://github.com/filiph/html_unescape
 
 environment:
-  sdk: '>=2.12.0-133.7.beta <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dev_dependencies:
   meta: ^1.3.0-nullsafety.6


### PR DESCRIPTION
Low score:
https://pub.dev/packages/html_unescape/versions/2.0.0-nullsafety.0/score

Log:
https://pub.dev/documentation/html_unescape/2.0.0-nullsafety.0/log.txt

Seems to me that `pub upgrade` runs with `flutter: 1.25.0-8.1.pre`, which doesn't support the latest sdk constrains:
```
ERR : The current Dart SDK version is 2.12.0-133.2.beta.
    | 
    | Because html_unescape requires SDK version >=2.12.0-133.7.beta <3.0.0, version solving failed.
```